### PR TITLE
add git as a buildtool depend

### DIFF
--- a/aws_common/package.xml
+++ b/aws_common/package.xml
@@ -11,6 +11,7 @@
   <license>Apache 2.0</license>
 
   <buildtool_depend>cmake</buildtool_depend>
+  <buildtool_depend>git</buildtool_depend>
 
   <build_depend>catkin</build_depend>
   <build_depend>ros_environment</build_depend>


### PR DESCRIPTION
To support checking out the external project from git

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
