### PR TITLE
Revert "Parameter Namespacing: Refactoring using the ParameterPath object."

### DIFF
--- a/aws_common/include/aws_common/sdk_utils/aws_error.h
+++ b/aws_common/include/aws_common/sdk_utils/aws_error.h
@@ -49,8 +49,6 @@ enum AwsError {
      action/event */
   AWS_ERR_NOT_ENOUGH_SPACE,
   /** An error indicating that a data structure is empty. */
-  AWS_ERR_EMPTY,
-  /** The feature is not supported. */
-  AWS_ERR_NOT_SUPPORTED,
+  AWS_ERR_EMPTY
 };
 }  // namespace Aws

--- a/aws_common/include/aws_common/sdk_utils/parameter_reader.h
+++ b/aws_common/include/aws_common/sdk_utils/parameter_reader.h
@@ -20,110 +20,6 @@
 namespace Aws {
 namespace Client {
 
-class ParameterPath {
-public:
-    /**
-     * Legacy constructor for backwards compatibility.
-     * @hint For ROS1, the node namespace separator is the same as the parameter namespace separator,
-     *     and so the path would simply be the given string (dictated by Ros1NodeParameterReader).
-     *   For ROS2 the separators differ; If only node namespace separators were found, we would treat them as parameter separators.
-     * @param name Parameter name, which in practice would be the path of the parameter, e.g. config/timeoutMs.
-     */
-    ParameterPath(const char * name) : name_(name) {}
-
-    /**
-     * @example The parameter under node "lidar_node" in namespace "sensor_nodes",
-     * with parameter namespace "settings" and parameter key "frequency", should be specified as follows:
-     *   node_namespace: ["sensor_nodes", "lidar_node"]
-     *   parameter_path_keys: ["settings", "frequency"]
-     * @note Node namespaces should be empty if used by a node looking for a parameter of its own (a local parameter).
-     * @param node_namespaces
-     * @param parameter_path_keys
-     */
-    ParameterPath(const std::vector<std::string> & node_namespaces, const std::vector<std::string> & parameter_path_keys) :
-      node_namespaces_(node_namespaces), parameter_path_keys_(parameter_path_keys) {}
-
-    /**
-     * @example The local parameter "timeout" in parameter namespace "config" should be specified as follows:
-     *   ParameterPath("config", "timeout")
-     * @tparam Args
-     * @param parameter_path_keys
-     */
-    template<typename ...Args>
-    ParameterPath(Args... parameter_path_keys) :
-      parameter_path_keys_(std::vector<std::string>{(parameter_path_keys)...}) {}
-
-    /**
-     * @note Only applies if node_namespaces was specified during construction; otherwise, an empty string is returned.
-     * @param node_namespace_separator
-     * @return string The parameter's whereabouts in the node namespace hierarchy.
-     */
-    std::string get_node_path(char node_namespace_separator) const
-    {
-        std::string resolved_path;
-        /* Construct the node's path by the provided lists of keys */
-        for (auto key = node_namespaces_.begin(); key != node_namespaces_.end(); key++) {
-            resolved_path += *key + node_namespace_separator;
-        }
-        if (!resolved_path.empty() && resolved_path.back() == node_namespace_separator) {
-            resolved_path.pop_back();
-        }
-        return resolved_path;
-    }
-    /**
-     * @note Only applies if parameter_path_keys was specified during construction; otherwise, an empty string is returned.
-     * @param parameter_namespace_separator
-     * @return string The parameter path including parameter namespaces but excluding node's namespaces.
-     */
-    std::string get_local_path(char parameter_namespace_separator) const
-    {
-        std::string resolved_path;
-        /* Construct the parameter's path by the provided lists of keys */
-        for (auto key = parameter_path_keys_.begin(); key != parameter_path_keys_.end(); key++) {
-            resolved_path += *key + parameter_namespace_separator;
-        }
-        if (!resolved_path.empty() && resolved_path.back() == parameter_namespace_separator) {
-            resolved_path.pop_back();
-        }
-        return resolved_path;
-    }
-    /**
-     * Resolves & returns the parameter's path. Supports two separate use cases:
-     *  1. A single, 'flat' string was provided upon construction.
-     *    In this case, we return it as is.
-     *  2. Detailed lists of strings were specified for the parameter & node namespaces.
-     *    In this case, we construct the resolved path using the provided separators.
-     * @param node_namespace_separator
-     * @param parameter_namespace_separator
-     * @return string representing the full, resolved path of the parameter.
-     * @note If node_namespaces and parameter_path_keys are empty, an empty string would be returned.
-     */
-    std::string get_resolved_path(char node_namespace_separator,
-                                  char parameter_namespace_separator) const
-    {
-      if (!name_.empty()) {
-        return name_;
-      } else {
-          std::string resolved_path = get_node_path(node_namespace_separator);
-          if (!resolved_path.empty()) {
-              resolved_path += node_namespace_separator;
-          }
-          resolved_path += get_local_path(parameter_namespace_separator);
-          return resolved_path;
-      }
-    }
-private:
-    /**
-     * Member variables to store the parameter's path in the namespace hierarchy.
-     * parameter_path_keys_ Parameter namespaces list.
-     * node_namespaces_ Node namespaces list.
-     * name_ A single string. Used when simpler initialization is required, instead of the aforementioned namespace lists.
-     */
-    const std::vector<std::string> parameter_path_keys_;
-    const std::vector<std::string> node_namespaces_;
-    const std::string name_;
-};
-
 class ParameterReaderInterface
 {
 public:
@@ -132,65 +28,58 @@ public:
   /**
    * read a list from the provided parameter name
    * @param name the name of the parameter to be read
-   * @param out the output of 'double' type.
+   * @param out the output of 'double' type
    * @return AWS_ERR_OK if read was successful, AWS_ERR_NOT_FOUND if the parameter was not found
-   * @note if the return code is not AWS_ERR_OK, out remains unchanged.
    */
-  virtual AwsError ReadList(const ParameterPath & parameter_path, std::vector<std::string> & out) const = 0;
+  virtual AwsError ReadList(const char * name, std::vector<std::string> & out) const = 0;
 
   /**
    * read a double value from the provided parameter name
-   * @param parameter_path an object representing the path of the parameter to be read
+   * @param name the name of the parameter to be read
    * @param out the output of 'double' type
    * @return AWS_ERR_OK if read was successful, AWS_ERR_NOT_FOUND if the parameter was not found
-   * @note if the return code is not AWS_ERR_OK, out remains unchanged.
    */
-  virtual AwsError ReadDouble(const ParameterPath & parameter_path, double & out) const = 0;
+  virtual AwsError ReadDouble(const char * name, double & out) const = 0;
 
   /**
    * read an integer value from the provided parameter name
-   * @param parameter_path an object representing the path of the parameter to be read
+   * @param name the name of the parameter to be read
    * @param out the output of 'int' type
    * @return AWS_ERR_OK if read was successful, AWS_ERR_NOT_FOUND if the parameter was not found
-   * @note if the return code is not AWS_ERR_OK, out remains unchanged.
    */
-  virtual AwsError ReadInt(const ParameterPath & parameter_path, int & out) const = 0;
+  virtual AwsError ReadInt(const char * name, int & out) const = 0;
 
   /**
    * read a boolean value from the provided parameter name
-   * @param parameter_path an object representing the path of the parameter to be read
+   * @param name the name of the parameter to be read
    * @param out the output of 'bool' type
    * @return AWS_ERR_OK if read was successful, AWS_ERR_NOT_FOUND if the parameter was not found
-   * @note if the return code is not AWS_ERR_OK, out remains unchanged.
    */
-  virtual AwsError ReadBool(const ParameterPath & parameter_path, bool & out) const = 0;
+  virtual AwsError ReadBool(const char * name, bool & out) const = 0;
 
   /**
    * read a string value from the provided parameter name
-   * @param parameter_path an object representing the path of the parameter to be read
+   * @param name the name of the parameter to be read
    * @param out the output of 'Aws::String' type
    * @return AWS_ERR_OK if read was successful, AWS_ERR_NOT_FOUND if the parameter was not found
-   * @note if the return code is not AWS_ERR_OK, out remains unchanged.
    */
-  virtual AwsError ReadString(const ParameterPath & parameter_path, Aws::String & out) const = 0;
+  virtual AwsError ReadString(const char * name, Aws::String & out) const = 0;
 
   /**
    * read a string from the provided parameter name
-   * @param parameter_path an object representing the path of the parameter to be read
+   * @param name the name of the parameter to be read
    * @param out the output of 'std::string' type
    * @return AWS_ERR_OK if read was successful, AWS_ERR_NOT_FOUND if the parameter was not found
-   * @note if the return code is not AWS_ERR_OK, out remains unchanged.
    */
-  virtual AwsError ReadStdString(const ParameterPath & parameter_path, std::string & out) const = 0;
+  virtual AwsError ReadStdString(const char * name, std::string & out) const = 0;
 
   /**
    * read a map from the provided parameter name
-   * @param parameter_path an object representing the path of the parameter to be read
+   * @param name the name of the parameter to be read
    * @param out the output of 'std::map' type
    * @return AWS_ERR_OK if read was successful, AWS_ERR_NOT_FOUND if the parameter was not found
-   * @note if the return code is not AWS_ERR_OK, out remains unchanged.
    */
-  virtual AwsError ReadMap(const ParameterPath & parameter_path, std::map<std::string, std::string> & out) const = 0;
+  virtual AwsError ReadMap(const char * name, std::map<std::string, std::string> & out) const = 0;
 };
 
 }  // namespace Client

--- a/aws_common/package.xml
+++ b/aws_common/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>aws_common</name>
-  <version>2.0.0</version>
+  <version>1.0.0</version>
   <description>Common AWS SDK utilities, intended for use by ROS packages using the AWS SDK</description>
   <url>http://wiki.ros.org/aws_common</url>
 

--- a/aws_common/src/sdk_utils/client_configuration_provider.cpp
+++ b/aws_common/src/sdk_utils/client_configuration_provider.cpp
@@ -86,39 +86,64 @@ ClientConfiguration ClientConfigurationProvider::GetClientConfiguration(
    * defaults to us-east-1).
    */
   config.region = profile_provider.GetProfile().GetRegion();
-  reader_->ReadString(ParameterPath(CLIENT_CONFIG_PREFIX, "region"), config.region);
+
+  Aws::String temp_string;
+  if (AWS_ERR_OK == reader_->ReadString(CLIENT_CONFIG_PREFIX "/region", temp_string)) {
+    config.region = temp_string;
+  } 
   PopulateUserAgent(config.userAgent, ros_version_override);
-  reader_->ReadString(ParameterPath(CLIENT_CONFIG_PREFIX, "user_agent"), config.userAgent);
-  reader_->ReadString(ParameterPath(CLIENT_CONFIG_PREFIX, "endpoint_override"), config.endpointOverride);
-  reader_->ReadString(ParameterPath(CLIENT_CONFIG_PREFIX, "proxy_host"), config.proxyHost);
-  reader_->ReadString(ParameterPath(CLIENT_CONFIG_PREFIX, "proxy_user_name"), config.proxyUserName);
-  reader_->ReadString(ParameterPath(CLIENT_CONFIG_PREFIX, "proxy_password"), config.proxyPassword);
-  reader_->ReadString(ParameterPath(CLIENT_CONFIG_PREFIX, "ca_path"), config.caPath);
-  reader_->ReadString(ParameterPath(CLIENT_CONFIG_PREFIX, "ca_file"), config.caFile);
+  if (AWS_ERR_OK == reader_->ReadString(CLIENT_CONFIG_PREFIX "/user_agent", temp_string)) {
+    config.userAgent = temp_string;
+  }
+  if (AWS_ERR_OK == reader_->ReadString(CLIENT_CONFIG_PREFIX "/endpoint_override", temp_string)) {
+    config.endpointOverride = temp_string;
+  }
+  if (AWS_ERR_OK == reader_->ReadString(CLIENT_CONFIG_PREFIX "/proxy_host", temp_string)) {
+    config.proxyHost = temp_string;
+  }
+  if (AWS_ERR_OK == reader_->ReadString(CLIENT_CONFIG_PREFIX "/proxy_user_name", temp_string)) {
+    config.proxyUserName = temp_string;
+  }
+  if (AWS_ERR_OK == reader_->ReadString(CLIENT_CONFIG_PREFIX "/proxy_password", temp_string)) {
+    config.proxyPassword = temp_string;
+  }
+  if (AWS_ERR_OK == reader_->ReadString(CLIENT_CONFIG_PREFIX "/ca_path", temp_string)) {
+    config.caPath = temp_string;
+  }
+  if (AWS_ERR_OK == reader_->ReadString(CLIENT_CONFIG_PREFIX "/ca_file", temp_string)) {
+    config.caFile = temp_string;
+  }
 
-  int temp;
-  if (AWS_ERR_OK == reader_->ReadInt(ParameterPath(CLIENT_CONFIG_PREFIX, "request_timeout_ms"), temp)) {
-    config.requestTimeoutMs = temp;
+  int temp_int;
+  if (AWS_ERR_OK == reader_->ReadInt(CLIENT_CONFIG_PREFIX "/request_timeout_ms", temp_int)) {
+    config.requestTimeoutMs = temp_int;
   }
-  if (AWS_ERR_OK == reader_->ReadInt(ParameterPath(CLIENT_CONFIG_PREFIX, "connect_timeout_ms"), temp)) {
-    config.connectTimeoutMs = temp;
+  if (AWS_ERR_OK == reader_->ReadInt(CLIENT_CONFIG_PREFIX "/connect_timeout_ms", temp_int)) {
+    config.connectTimeoutMs = temp_int;
   }
-  if (AWS_ERR_OK == reader_->ReadInt(ParameterPath(CLIENT_CONFIG_PREFIX, "max_connections"), temp)) {
-    config.maxConnections = temp;
+  if (AWS_ERR_OK == reader_->ReadInt(CLIENT_CONFIG_PREFIX "/max_connections", temp_int)) {
+    config.maxConnections = temp_int;
   }
-  if (AWS_ERR_OK == reader_->ReadInt(ParameterPath(CLIENT_CONFIG_PREFIX, "proxy_port"), temp)) {
-    config.proxyPort = temp;
+  if (AWS_ERR_OK == reader_->ReadInt(CLIENT_CONFIG_PREFIX "/proxy_port", temp_int)) {
+    config.proxyPort = temp_int;
   }
 
-  reader_->ReadBool(ParameterPath(CLIENT_CONFIG_PREFIX, "use_dual_stack"), config.useDualStack);
-  reader_->ReadBool(ParameterPath(CLIENT_CONFIG_PREFIX, "enable_clock_skew_adjustment"),
-                    config.enableClockSkewAdjustment);
-  reader_->ReadBool(ParameterPath(CLIENT_CONFIG_PREFIX, "follow_redirects"), config.followRedirects);
-  reader_->ReadBool(ParameterPath(CLIENT_CONFIG_PREFIX, "verify_SSL"), config.verifySSL);
+  bool temp_bool;
+  if (AWS_ERR_OK == reader_->ReadBool(CLIENT_CONFIG_PREFIX "/use_dual_stack", temp_bool)) {
+    config.useDualStack = temp_bool;
+  }
+  if (AWS_ERR_OK == reader_->ReadBool(CLIENT_CONFIG_PREFIX "/enable_clock_skew_adjustment", temp_bool)) {
+    config.enableClockSkewAdjustment = temp_bool;
+  }
+  if (AWS_ERR_OK == reader_->ReadBool(CLIENT_CONFIG_PREFIX "/follow_redirects", temp_bool)) {
+    config.followRedirects = temp_bool;
+  }
+  if (AWS_ERR_OK == reader_->ReadBool(CLIENT_CONFIG_PREFIX "/verify_SSL", temp_bool)) {
+    config.verifySSL = temp_bool;
+  }
 
-  int max_retries;
-  if (AWS_ERR_OK == reader_->ReadInt(ParameterPath(CLIENT_CONFIG_PREFIX, "max_retries"), max_retries)) {
-    config.retryStrategy = std::make_shared<Aws::Client::DefaultRetryStrategy>(max_retries);
+  if (AWS_ERR_OK == reader_->ReadInt(CLIENT_CONFIG_PREFIX "/max_retries", temp_int)) {
+    config.retryStrategy = std::make_shared<Aws::Client::DefaultRetryStrategy>(temp_int);
   }
 
   return config;

--- a/aws_common/test/include/aws_common/sdk_utils/parameter_reader_mock.h
+++ b/aws_common/test/include/aws_common/sdk_utils/parameter_reader_mock.h
@@ -23,13 +23,13 @@ namespace Client {
 class ParameterReaderMock : public ParameterReaderInterface 
 {
 public:
-  MOCK_CONST_METHOD2(ReadList, Aws::AwsError(const ParameterPath &, std::vector<std::string> &));
-  MOCK_CONST_METHOD2(ReadDouble, Aws::AwsError(const ParameterPath &, double &));
-  MOCK_CONST_METHOD2(ReadInt, Aws::AwsError(const ParameterPath &, int &));
-  MOCK_CONST_METHOD2(ReadBool, Aws::AwsError(const ParameterPath &, bool &));
-  MOCK_CONST_METHOD2(ReadString, Aws::AwsError(const ParameterPath &, Aws::String &));
-  MOCK_CONST_METHOD2(ReadStdString, Aws::AwsError(const ParameterPath &, std::string &));
-  MOCK_CONST_METHOD2(ReadMap, Aws::AwsError(const ParameterPath &, std::map<std::string, std::string> &));
+  MOCK_CONST_METHOD2(ReadList, Aws::AwsError(const char *, std::vector<std::string> &));
+  MOCK_CONST_METHOD2(ReadDouble, Aws::AwsError(const char *, double &));
+  MOCK_CONST_METHOD2(ReadInt, Aws::AwsError(const char *, int &));
+  MOCK_CONST_METHOD2(ReadBool, Aws::AwsError(const char *, bool &));
+  MOCK_CONST_METHOD2(ReadString, Aws::AwsError(const char *, Aws::String &));
+  MOCK_CONST_METHOD2(ReadStdString, Aws::AwsError(const char *, std::string &));
+  MOCK_CONST_METHOD2(ReadMap, Aws::AwsError(const char *, std::map<std::string, std::string> &));
 };
 
 }  // namespace Client

--- a/aws_common/test/sdk_utils/client_configuration_provider_test.cpp
+++ b/aws_common/test/sdk_utils/client_configuration_provider_test.cpp
@@ -75,11 +75,11 @@ TEST_F(ClientConfigurationProviderFixture, TestAllReaderErrorsIgnored)
 
   ClientConfiguration config = test_subject_->GetClientConfiguration();
 
-  EXPECT_EQ(unexpected_str, config.region);
+  EXPECT_NE(unexpected_str, config.region);
   EXPECT_NE(unkExpectedInt, config.maxConnections);
-  EXPECT_EQ(unkExpectedBool, config.useDualStack);
+  EXPECT_NE(unkExpectedBool, config.useDualStack);
   EXPECT_EQ(default_config.maxConnections, config.maxConnections);
-  EXPECT_NE(default_config.useDualStack, config.useDualStack);
+  EXPECT_EQ(default_config.useDualStack, config.useDualStack);
 }
 
 TEST_F(ClientConfigurationProviderFixture, TestRosVersionOverride) {


### PR DESCRIPTION
Reverts aws-robotics/utils-common#10

I'd like to merge the related changes across all cloud extensions simultaneously to minimize the risk of someone pulling in the master of all CEs and expecting it to work; so reverting this for now.