### PR TITLE
Remove legacy portions of the ParameterReader API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,12 @@ env:
   matrix:
     - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-    - ROS_DISTRO="lunar"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - ROS_DISTRO="lunar"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     - ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
   global:
     - AFTER_SCRIPT='if [ -z "$PRERELEASE" ] || [ "$PRERELEASE" != true ]; then cd ~/catkin_ws && catkin build --pre-clean --catkin-make-args run_tests && catkin_test_results --verbose; fi;'
 matrix:
   allow_failures:
-    - env: ROS_DISTRO="lunar"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - env: ROS_DISTRO="lunar"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     - env: ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - env: ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
 install:

--- a/aws_common/include/aws_common/sdk_utils/parameter_reader.h
+++ b/aws_common/include/aws_common/sdk_utils/parameter_reader.h
@@ -14,6 +14,7 @@
  */
 
 #pragma once
+
 #include <aws/core/client/ClientConfiguration.h>
 #include <aws/core/utils/StringUtils.h>
 #include <aws_common/sdk_utils/aws_error.h>
@@ -115,7 +116,6 @@ class ParameterReaderInterface
 public:
   virtual ~ParameterReaderInterface() = default;
 
-
   /**
    * read a list from the provided parameter name
    * @param name the name of the parameter to be read
@@ -123,74 +123,7 @@ public:
    * @return AWS_ERR_OK if read was successful, AWS_ERR_NOT_FOUND if the parameter was not found
    * @note if the return code is not AWS_ERR_OK, out remains unchanged.
    */
-  virtual AwsError ReadList(const char * name, std::vector<std::string> & out) const = 0;
-
-  /**
-   * read a double value from the provided parameter name
-   * @param name the name of the parameter to be read
-   * @param out the output of 'double' type
-   * @return AWS_ERR_OK if read was successful, AWS_ERR_NOT_FOUND if the parameter was not found
-   * @note if the return code is not AWS_ERR_OK, out remains unchanged.
-   */
-  virtual AwsError ReadDouble(const char * name, double & out) const = 0;
-
-  /**
-   * read an integer value from the provided parameter name
-   * @param name the name of the parameter to be read
-   * @param out the output of 'int' type
-   * @return AWS_ERR_OK if read was successful, AWS_ERR_NOT_FOUND if the parameter was not found
-   * @note if the return code is not AWS_ERR_OK, out remains unchanged.
-   */
-  virtual AwsError ReadInt(const char * name, int & out) const = 0;
-
-  /**
-   * read a boolean value from the provided parameter name
-   * @param name the name of the parameter to be read
-   * @param out the output of 'bool' type
-   * @return AWS_ERR_OK if read was successful, AWS_ERR_NOT_FOUND if the parameter was not found
-   * @note if the return code is not AWS_ERR_OK, out remains unchanged.
-   */
-  virtual AwsError ReadBool(const char * name, bool & out) const = 0;
-
-  /**
-   * read a string value from the provided parameter name
-   * @param name the name of the parameter to be read
-   * @param out the output of 'Aws::String' type
-   * @return AWS_ERR_OK if read was successful, AWS_ERR_NOT_FOUND if the parameter was not found
-   * @note if the return code is not AWS_ERR_OK, out remains unchanged.
-   */
-  virtual AwsError ReadString(const char * name, Aws::String & out) const = 0;
-
-  /**
-   * read a string from the provided parameter name
-   * @param name the name of the parameter to be read
-   * @param out the output of 'std::string' type
-   * @return AWS_ERR_OK if read was successful, AWS_ERR_NOT_FOUND if the parameter was not found
-   * @note if the return code is not AWS_ERR_OK, out remains unchanged.
-   */
-  virtual AwsError ReadStdString(const char * name, std::string & out) const = 0;
-
-  /**
-   * read a map from the provided parameter name
-   * @param name the name of the parameter to be read
-   * @param out the output of 'std::map' type
-   * @return AWS_ERR_OK if read was successful, AWS_ERR_NOT_FOUND if the parameter was not found
-   * @note if the return code is not AWS_ERR_OK, out remains unchanged.
-   */
-  virtual AwsError ReadMap(const char * name, std::map<std::string, std::string> & out) const = 0;
-
-
-  /**
-   * read a list from the provided parameter name
-   * @param name the name of the parameter to be read
-   * @param out the output of 'double' type.
-   * @return AWS_ERR_OK if read was successful, AWS_ERR_NOT_FOUND if the parameter was not found
-   * @note if the return code is not AWS_ERR_OK, out remains unchanged.
-   */
-  AwsError ReadList(const ParameterPath & param_path, std::vector<std::string> & out) const
-  {
-    return ReadList(FormatParameterPath(param_path).c_str(), out);
-  }
+  virtual AwsError ReadParam(const ParameterPath & param_path, std::vector<std::string> & out) const = 0;
 
   /**
    * read a double value from the provided parameter name
@@ -199,10 +132,7 @@ public:
    * @return AWS_ERR_OK if read was successful, AWS_ERR_NOT_FOUND if the parameter was not found
    * @note if the return code is not AWS_ERR_OK, out remains unchanged.
    */
-  AwsError ReadDouble(const ParameterPath & param_path, double & out) const
-  {
-    return ReadDouble(FormatParameterPath(param_path).c_str(), out);
-  }
+  virtual AwsError ReadParam(const ParameterPath & param_path, double & out) const = 0;
 
   /**
    * read an integer value from the provided parameter name
@@ -211,10 +141,7 @@ public:
    * @return AWS_ERR_OK if read was successful, AWS_ERR_NOT_FOUND if the parameter was not found
    * @note if the return code is not AWS_ERR_OK, out remains unchanged.
    */
-  AwsError ReadInt(const ParameterPath & param_path, int & out) const
-  {
-    return ReadInt(FormatParameterPath(param_path).c_str(), out);
-  }
+  virtual AwsError ReadParam(const ParameterPath & param_path, int & out) const = 0;
 
   /**
    * read a boolean value from the provided parameter name
@@ -223,10 +150,7 @@ public:
    * @return AWS_ERR_OK if read was successful, AWS_ERR_NOT_FOUND if the parameter was not found
    * @note if the return code is not AWS_ERR_OK, out remains unchanged.
    */
-  AwsError ReadBool(const ParameterPath & param_path, bool & out) const
-  {
-    return ReadBool(FormatParameterPath(param_path).c_str(), out);
-  }
+  virtual AwsError ReadParam(const ParameterPath & param_path, bool & out) const = 0;
 
   /**
    * read a string value from the provided parameter name
@@ -235,10 +159,7 @@ public:
    * @return AWS_ERR_OK if read was successful, AWS_ERR_NOT_FOUND if the parameter was not found
    * @note if the return code is not AWS_ERR_OK, out remains unchanged.
    */
-  AwsError ReadString(const ParameterPath & param_path, Aws::String & out) const
-  {
-    return ReadString(FormatParameterPath(param_path).c_str(), out);
-  }
+  virtual AwsError ReadParam(const ParameterPath & param_path, Aws::String & out) const = 0;
 
   /**
    * read a string from the provided parameter name
@@ -247,10 +168,7 @@ public:
    * @return AWS_ERR_OK if read was successful, AWS_ERR_NOT_FOUND if the parameter was not found
    * @note if the return code is not AWS_ERR_OK, out remains unchanged.
    */
-  AwsError ReadStdString(const ParameterPath & param_path, std::string & out) const
-  {
-    return ReadStdString(FormatParameterPath(param_path).c_str(), out);
-  }
+  virtual AwsError ReadParam(const ParameterPath & param_path, std::string & out) const = 0;
 
   /**
    * read a map from the provided parameter name
@@ -259,19 +177,29 @@ public:
    * @return AWS_ERR_OK if read was successful, AWS_ERR_NOT_FOUND if the parameter was not found
    * @note if the return code is not AWS_ERR_OK, out remains unchanged.
    */
-  AwsError ReadMap(const ParameterPath & param_path, std::map<std::string, std::string> & out) const
-  {
-    return ReadMap(FormatParameterPath(param_path).c_str(), out);
-  }
-
+  virtual AwsError ReadParam(const ParameterPath & param_path, std::map<std::string, std::string> & out) const = 0;
 
 private:
-  /**
-   * format the provided ParameterPath object into the a string containing the desired parameter name
-   * @param param_path an object representing the path of the parameter to be read
-   * @return the formatted string
-   */
-  virtual std::string FormatParameterPath(const ParameterPath & param_path) const = 0;
+  template<class InvalidType>
+  AwsError ReadParam(InvalidType arg, std::vector<std::string> & out) const = delete;
+  
+  template<class InvalidType>
+  AwsError ReadParam(InvalidType arg, double & out) const = delete;
+  
+  template<class InvalidType>
+  AwsError ReadParam(InvalidType arg, int & out) const = delete;
+  
+  template<class InvalidType>
+  AwsError ReadParam(InvalidType arg, bool & out) const = delete;
+  
+  template<class InvalidType>
+  AwsError ReadParam(InvalidType arg, Aws::String & out) const = delete;
+  
+  template<class InvalidType>
+  AwsError ReadParam(InvalidType arg, std::string & out) const = delete;
+  
+  template<class InvalidType>
+  AwsError ReadParam(InvalidType arg, std::map<std::string, std::string> & out) const = delete;
 };
 
 }  // namespace Client

--- a/aws_common/src/sdk_utils/auth/service_credentials_provider.cpp
+++ b/aws_common/src/sdk_utils/auth/service_credentials_provider.cpp
@@ -201,7 +201,7 @@ bool GetServiceAuthConfig(ServiceAuthConfig & config,
   long total_timeout_ms = DEFAULT_AUTH_TOTAL_TIMEOUT_MS;
 
   std::map<std::string, std::string> data;
-  if (parameters->ReadMap("iot", data) != AWS_ERR_OK) {
+  if (parameters->ReadParam(Aws::Client::ParameterPath("iot"), data) != AWS_ERR_OK) {
     failed = true;
   } else {
     if (!GetConfigValue(data, CFG_CAFILE, cafile)) failed = true;

--- a/aws_common/src/sdk_utils/client_configuration_provider.cpp
+++ b/aws_common/src/sdk_utils/client_configuration_provider.cpp
@@ -86,38 +86,38 @@ ClientConfiguration ClientConfigurationProvider::GetClientConfiguration(
    * defaults to us-east-1).
    */
   config.region = profile_provider.GetProfile().GetRegion();
-  reader_->ReadString(ParameterPath(CLIENT_CONFIG_PREFIX, "region"), config.region);
+  reader_->ReadParam(ParameterPath(CLIENT_CONFIG_PREFIX, "region"), config.region);
   PopulateUserAgent(config.userAgent, ros_version_override);
-  reader_->ReadString(ParameterPath(CLIENT_CONFIG_PREFIX, "user_agent"), config.userAgent);
-  reader_->ReadString(ParameterPath(CLIENT_CONFIG_PREFIX, "endpoint_override"), config.endpointOverride);
-  reader_->ReadString(ParameterPath(CLIENT_CONFIG_PREFIX, "proxy_host"), config.proxyHost);
-  reader_->ReadString(ParameterPath(CLIENT_CONFIG_PREFIX, "proxy_user_name"), config.proxyUserName);
-  reader_->ReadString(ParameterPath(CLIENT_CONFIG_PREFIX, "proxy_password"), config.proxyPassword);
-  reader_->ReadString(ParameterPath(CLIENT_CONFIG_PREFIX, "ca_path"), config.caPath);
-  reader_->ReadString(ParameterPath(CLIENT_CONFIG_PREFIX, "ca_file"), config.caFile);
+  reader_->ReadParam(ParameterPath(CLIENT_CONFIG_PREFIX, "user_agent"), config.userAgent);
+  reader_->ReadParam(ParameterPath(CLIENT_CONFIG_PREFIX, "endpoint_override"), config.endpointOverride);
+  reader_->ReadParam(ParameterPath(CLIENT_CONFIG_PREFIX, "proxy_host"), config.proxyHost);
+  reader_->ReadParam(ParameterPath(CLIENT_CONFIG_PREFIX, "proxy_user_name"), config.proxyUserName);
+  reader_->ReadParam(ParameterPath(CLIENT_CONFIG_PREFIX, "proxy_password"), config.proxyPassword);
+  reader_->ReadParam(ParameterPath(CLIENT_CONFIG_PREFIX, "ca_path"), config.caPath);
+  reader_->ReadParam(ParameterPath(CLIENT_CONFIG_PREFIX, "ca_file"), config.caFile);
 
   int temp;
-  if (AWS_ERR_OK == reader_->ReadInt(ParameterPath(CLIENT_CONFIG_PREFIX, "request_timeout_ms"), temp)) {
+  if (AWS_ERR_OK == reader_->ReadParam(ParameterPath(CLIENT_CONFIG_PREFIX, "request_timeout_ms"), temp)) {
     config.requestTimeoutMs = temp;
   }
-  if (AWS_ERR_OK == reader_->ReadInt(ParameterPath(CLIENT_CONFIG_PREFIX, "connect_timeout_ms"), temp)) {
+  if (AWS_ERR_OK == reader_->ReadParam(ParameterPath(CLIENT_CONFIG_PREFIX, "connect_timeout_ms"), temp)) {
     config.connectTimeoutMs = temp;
   }
-  if (AWS_ERR_OK == reader_->ReadInt(ParameterPath(CLIENT_CONFIG_PREFIX, "max_connections"), temp)) {
+  if (AWS_ERR_OK == reader_->ReadParam(ParameterPath(CLIENT_CONFIG_PREFIX, "max_connections"), temp)) {
     config.maxConnections = temp;
   }
-  if (AWS_ERR_OK == reader_->ReadInt(ParameterPath(CLIENT_CONFIG_PREFIX, "proxy_port"), temp)) {
+  if (AWS_ERR_OK == reader_->ReadParam(ParameterPath(CLIENT_CONFIG_PREFIX, "proxy_port"), temp)) {
     config.proxyPort = temp;
   }
 
-  reader_->ReadBool(ParameterPath(CLIENT_CONFIG_PREFIX, "use_dual_stack"), config.useDualStack);
-  reader_->ReadBool(ParameterPath(CLIENT_CONFIG_PREFIX, "enable_clock_skew_adjustment"),
+  reader_->ReadParam(ParameterPath(CLIENT_CONFIG_PREFIX, "use_dual_stack"), config.useDualStack);
+  reader_->ReadParam(ParameterPath(CLIENT_CONFIG_PREFIX, "enable_clock_skew_adjustment"),
                     config.enableClockSkewAdjustment);
-  reader_->ReadBool(ParameterPath(CLIENT_CONFIG_PREFIX, "follow_redirects"), config.followRedirects);
-  reader_->ReadBool(ParameterPath(CLIENT_CONFIG_PREFIX, "verify_SSL"), config.verifySSL);
+  reader_->ReadParam(ParameterPath(CLIENT_CONFIG_PREFIX, "follow_redirects"), config.followRedirects);
+  reader_->ReadParam(ParameterPath(CLIENT_CONFIG_PREFIX, "verify_SSL"), config.verifySSL);
 
   int max_retries;
-  if (AWS_ERR_OK == reader_->ReadInt(ParameterPath(CLIENT_CONFIG_PREFIX, "max_retries"), max_retries)) {
+  if (AWS_ERR_OK == reader_->ReadParam(ParameterPath(CLIENT_CONFIG_PREFIX, "max_retries"), max_retries)) {
     config.retryStrategy = std::make_shared<Aws::Client::DefaultRetryStrategy>(max_retries);
   }
 

--- a/aws_common/test/include/aws_common/sdk_utils/parameter_reader_mock.h
+++ b/aws_common/test/include/aws_common/sdk_utils/parameter_reader_mock.h
@@ -23,16 +23,13 @@ namespace Client {
 class ParameterReaderMock : public ParameterReaderInterface 
 {
 public:
-  MOCK_CONST_METHOD2(ReadList, Aws::AwsError(const char *, std::vector<std::string> &));
-  MOCK_CONST_METHOD2(ReadDouble, Aws::AwsError(const char *, double &));
-  MOCK_CONST_METHOD2(ReadInt, Aws::AwsError(const char *, int &));
-  MOCK_CONST_METHOD2(ReadBool, Aws::AwsError(const char *, bool &));
-  MOCK_CONST_METHOD2(ReadString, Aws::AwsError(const char *, Aws::String &));
-  MOCK_CONST_METHOD2(ReadStdString, Aws::AwsError(const char *, std::string &));
-  MOCK_CONST_METHOD2(ReadMap, Aws::AwsError(const char *, std::map<std::string, std::string> &));
-
-private:
-  MOCK_CONST_METHOD1(FormatParameterPath, std::string(const ParameterPath &));
+  MOCK_CONST_METHOD2(ReadParam, Aws::AwsError(const ParameterPath &, std::vector<std::string> &));
+  MOCK_CONST_METHOD2(ReadParam, Aws::AwsError(const ParameterPath &, double &));
+  MOCK_CONST_METHOD2(ReadParam, Aws::AwsError(const ParameterPath &, int &));
+  MOCK_CONST_METHOD2(ReadParam, Aws::AwsError(const ParameterPath &, bool &));
+  MOCK_CONST_METHOD2(ReadParam, Aws::AwsError(const ParameterPath &, Aws::String &));
+  MOCK_CONST_METHOD2(ReadParam, Aws::AwsError(const ParameterPath &, std::string &));
+  MOCK_CONST_METHOD2(ReadParam, Aws::AwsError(const ParameterPath &, std::map<std::string, std::string> &));
 };
 
 }  // namespace Client

--- a/aws_common/test/sdk_utils/auth/service_credentials_provider_test.cpp
+++ b/aws_common/test/sdk_utils/auth/service_credentials_provider_test.cpp
@@ -24,10 +24,11 @@ using namespace Aws::Client;
 using namespace Aws::Utils;
 using namespace Aws::Auth;
 using namespace Aws::Utils::Json;
+using ::testing::_;
+using ::testing::Matcher;
 using ::testing::DoAll;
 using ::testing::SetArgReferee;
 using ::testing::Return;
-using ::testing::_;
 using ::testing::NiceMock;
 using Aws::AwsError;
 
@@ -95,7 +96,7 @@ const std::list<std::string> ServiceCredentialsProviderFixture::kFullCredentials
 
 TEST_F(ServiceCredentialsProviderFixture, TestGetServiceAuthConfigNoIotConfig)
 {
-  EXPECT_CALL(*param_reader_, ReadMap(::testing::_, ::testing::_ ))
+  EXPECT_CALL(*param_reader_, ReadParam(_, Matcher<std::map<std::string, std::string> &>(_)))
     .WillRepeatedly(Return(AwsError::AWS_ERR_NOT_FOUND));
 
   ServiceAuthConfig config; 
@@ -113,7 +114,7 @@ TEST_P(TestGetServiceAuthConfigFixture, TestGetServiceAuthConfigPartialIotConfig
   auto missing_config_key = GetParam();
   auto partial_iot_config = std::map<std::string, std::string>(kFullIotConfigMap);
   partial_iot_config.erase(missing_config_key);
-  EXPECT_CALL(*param_reader_, ReadMap(::testing::_, ::testing::_ ))
+  EXPECT_CALL(*param_reader_, ReadParam(_, Matcher<std::map<std::string, std::string> &>(_)))
     .WillRepeatedly(DoAll(SetArgReferee<1>(partial_iot_config), Return(AwsError::AWS_ERR_OK)));
 
   ServiceAuthConfig config; 
@@ -130,7 +131,7 @@ INSTANTIATE_TEST_CASE_P(
 
 TEST_F(ServiceCredentialsProviderFixture, TestGetServiceAuthConfigCompleteIotConfig)
 {
-  EXPECT_CALL(*param_reader_, ReadMap(::testing::_, ::testing::_ ))
+  EXPECT_CALL(*param_reader_, ReadParam(_, Matcher<std::map<std::string, std::string> &>(_)))
     .WillRepeatedly(DoAll(SetArgReferee<1>(kFullIotConfigMap), Return(AwsError::AWS_ERR_OK)));
 
   ServiceAuthConfig config; 

--- a/aws_common/test/sdk_utils/client_configuration_provider_test.cpp
+++ b/aws_common/test/sdk_utils/client_configuration_provider_test.cpp
@@ -18,10 +18,11 @@
 #include <aws_common/sdk_utils/client_configuration_provider.h>
 
 using namespace Aws::Client;
+using ::testing::_;
+using ::testing::Matcher;
 using ::testing::DoAll;
 using ::testing::SetArgReferee;
 using ::testing::Return;
-using ::testing::_;
 using Aws::AwsError;
 
 class ClientConfigurationProviderFixture : public ::testing::Test
@@ -39,17 +40,17 @@ TEST_F(ClientConfigurationProviderFixture, TestReaderRespected)
   const int kExpectedInt = 64654;
   const bool kExpectedBool = true;
 
-  EXPECT_CALL(*param_reader_, ReadList(::testing::_, ::testing::_ ))
+  EXPECT_CALL(*param_reader_, ReadParam(_, Matcher<std::vector<std::string> &>(_)))
    .WillRepeatedly(Return(AwsError::AWS_ERR_OK));
-  EXPECT_CALL(*param_reader_, ReadDouble(::testing::_, ::testing::_ ))
+  EXPECT_CALL(*param_reader_, ReadParam(_, Matcher<double &>(_)))
    .WillRepeatedly(Return(AwsError::AWS_ERR_OK));
-  EXPECT_CALL(*param_reader_, ReadStdString(::testing::_, ::testing::_ ))
+  EXPECT_CALL(*param_reader_, ReadParam(_, Matcher<std::string &>(_)))
    .WillRepeatedly(Return(AwsError::AWS_ERR_OK));
-  EXPECT_CALL(*param_reader_, ReadString(::testing::_, ::testing::_ ))
+  EXPECT_CALL(*param_reader_, ReadParam(_, Matcher<Aws::String &>(_)))
     .WillRepeatedly(DoAll(SetArgReferee<1>(expected_str), Return(AwsError::AWS_ERR_OK)));
-  EXPECT_CALL(*param_reader_, ReadInt(::testing::_, ::testing::_ ))
+  EXPECT_CALL(*param_reader_, ReadParam(_, Matcher<int &>(_)))
     .WillRepeatedly(DoAll(SetArgReferee<1>(kExpectedInt), Return(AwsError::AWS_ERR_OK)));
-  EXPECT_CALL(*param_reader_, ReadBool(::testing::_, ::testing::_ ))
+  EXPECT_CALL(*param_reader_, ReadParam(_, Matcher<bool &>(_)))
     .WillRepeatedly(DoAll(SetArgReferee<1>(kExpectedBool), Return(AwsError::AWS_ERR_OK)));
 
   ClientConfiguration config = test_subject_->GetClientConfiguration();
@@ -66,11 +67,11 @@ TEST_F(ClientConfigurationProviderFixture, TestAllReaderErrorsIgnored)
   const int unkExpectedInt = default_config.maxConnections + 45231;
   const bool unkExpectedBool = !default_config.useDualStack;
 
-  EXPECT_CALL(*param_reader_, ReadString(::testing::_, ::testing::_ ))
+  EXPECT_CALL(*param_reader_, ReadParam(_, Matcher<Aws::String &>(_)))
     .WillRepeatedly(DoAll(SetArgReferee<1>(unexpected_str), Return(AwsError::AWS_ERR_FAILURE)));
-  EXPECT_CALL(*param_reader_, ReadInt(::testing::_, ::testing::_ ))
+  EXPECT_CALL(*param_reader_, ReadParam(_, Matcher<int &>(_)))
     .WillRepeatedly(DoAll(SetArgReferee<1>(unkExpectedInt), Return(AwsError::AWS_ERR_NOT_FOUND)));
-  EXPECT_CALL(*param_reader_, ReadBool(::testing::_, ::testing::_ ))
+  EXPECT_CALL(*param_reader_, ReadParam(_, Matcher<bool &>(_)))
     .WillRepeatedly(DoAll(SetArgReferee<1>(unkExpectedBool), Return(AwsError::AWS_ERR_EMPTY)));
 
   ClientConfiguration config = test_subject_->GetClientConfiguration();
@@ -83,11 +84,11 @@ TEST_F(ClientConfigurationProviderFixture, TestAllReaderErrorsIgnored)
 }
 
 TEST_F(ClientConfigurationProviderFixture, TestRosVersionOverride) {
-  EXPECT_CALL(*param_reader_, ReadString(::testing::_, ::testing::_ ))
+  EXPECT_CALL(*param_reader_, ReadParam(_, Matcher<Aws::String &>(_)))
     .WillRepeatedly(Return(AwsError::AWS_ERR_NOT_FOUND));
-  EXPECT_CALL(*param_reader_, ReadInt(::testing::_, ::testing::_ ))
+  EXPECT_CALL(*param_reader_, ReadParam(_, Matcher<int &>(_)))
     .WillRepeatedly(Return(AwsError::AWS_ERR_NOT_FOUND));
-  EXPECT_CALL(*param_reader_, ReadBool(::testing::_, ::testing::_ ))
+  EXPECT_CALL(*param_reader_, ReadParam(_, Matcher<bool &>(_)))
     .WillRepeatedly(Return(AwsError::AWS_ERR_NOT_FOUND));
 
   ClientConfiguration config1 = test_subject_->GetClientConfiguration();


### PR DESCRIPTION
*Description of changes:*

We have decided to remove the legacy portions of the ParameterReader API. ParameterReader will now only accept ParameterPath objects for addressing parameters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.