### PR TITLE
Add NoRetryStrategy

### DIFF
--- a/aws_common/package.xml
+++ b/aws_common/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>aws_common</name>
-  <version>2.0.0</version>
+  <version>2.1.0</version>
   <description>Common AWS SDK utilities, intended for use by ROS packages using the AWS SDK</description>
   <url>http://wiki.ros.org/aws_common</url>
 

--- a/aws_common/src/sdk_utils/client_configuration_provider.cpp
+++ b/aws_common/src/sdk_utils/client_configuration_provider.cpp
@@ -29,18 +29,24 @@ namespace Client {
 /**
  *
  */
-class NoRetryStrategy : public DefaultRetryStrategy
+class NoRetryStrategy : public RetryStrategy
 {
 public:
-    NoRetryStrategy() : DefaultRetryStrategy(0,0) {}
-    NoRetryStrategy(int i, int j) : DefaultRetryStrategy(0,0) {}
+  NoRetryStrategy() = default;
 
-    bool ShouldRetry(const AWSError<CoreErrors>& error, long attemptedRetries) const override
-    {
-      return false;
-    }
-    int GetAttemptedRetriesCount() { return 0; }
-    void ResetAttemptedRetriesCount() { }
+  bool ShouldRetry(const AWSError<CoreErrors> & error, long attemptedRetries) const override
+  {
+    AWS_UNREFERENCED_PARAM(error);
+    AWS_UNREFERENCED_PARAM(attemptedRetries);
+    return false;
+  }
+
+  long CalculateDelayBeforeNextRetry(const AWSError<CoreErrors> & error, long attemptedRetries) const
+  {
+    AWS_UNREFERENCED_PARAM(error);
+    AWS_UNREFERENCED_PARAM(attemptedRetries);
+    return 0;
+  }
 };
 
 
@@ -139,17 +145,14 @@ ClientConfiguration ClientConfigurationProvider::GetClientConfiguration(
   auto error = reader_->ReadParam(ParameterPath(CLIENT_CONFIG_PREFIX, "no_retry_strategy"), strategy);
 
   if (AWS_ERR_OK == error && strategy) {
-    config.retryStrategy = std::make_shared<NoRetryStrategy>(0,0);
+    config.retryStrategy = std::make_shared<NoRetryStrategy>();
   } else {
-
     // if max retries is set use the DefaultRetryStrategy
     int max_retries;
     if (AWS_ERR_OK == reader_->ReadParam(ParameterPath(CLIENT_CONFIG_PREFIX, "max_retries"), max_retries)) {
-
       config.retryStrategy = std::make_shared<Aws::Client::DefaultRetryStrategy>(max_retries);
     }
   }
-
 
   return config;
 }

--- a/aws_common/src/sdk_utils/client_configuration_provider.cpp
+++ b/aws_common/src/sdk_utils/client_configuration_provider.cpp
@@ -140,14 +140,16 @@ ClientConfiguration ClientConfigurationProvider::GetClientConfiguration(
 
   if (AWS_ERR_OK == error && strategy) {
     config.retryStrategy = std::make_shared<NoRetryStrategy>(0,0);
+  } else {
+
+    // if max retries is set use the DefaultRetryStrategy
+    int max_retries;
+    if (AWS_ERR_OK == reader_->ReadParam(ParameterPath(CLIENT_CONFIG_PREFIX, "max_retries"), max_retries)) {
+
+      config.retryStrategy = std::make_shared<Aws::Client::DefaultRetryStrategy>(max_retries);
+    }
   }
 
-  // if max retries is set use the DefaultRetryStrategy
-  int max_retries;
-  if (AWS_ERR_OK == reader_->ReadParam(ParameterPath(CLIENT_CONFIG_PREFIX, "max_retries"), max_retries)) {
-
-    config.retryStrategy = std::make_shared<Aws::Client::DefaultRetryStrategy>(max_retries);
-  }
 
   return config;
 }


### PR DESCRIPTION
*Description of changes:*

This new retry strategy is needed by the upcoming Cloudwatch offline feature.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.