### PR TITLE
Add buildtool dependency on ament_cmake_gtest/gmock for ROS2

### DIFF
--- a/aws_common/package.xml
+++ b/aws_common/package.xml
@@ -12,7 +12,9 @@
 
   <buildtool_depend>cmake</buildtool_depend>
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
-
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake_gtest</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake_gmock</buildtool_depend>
+  
   <build_depend>ros_environment</build_depend>
 
   <depend>zlib</depend>


### PR DESCRIPTION
`aws_common` needs `ament_cmake_g*` not only for its own tests, but also as a buildtool dependency because it exports test macros (same reason catkin is needed as a buildtool dependency for ROS1 builds).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
