### PR TITLE
Set travis to always send email on success.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ compiler:
   - gcc
 notifications:
   email:
-    on_success: change
+    on_success: always
     on_failure: always
     recipients:
       - ros-contributions@amazon.com


### PR DESCRIPTION
We got into a weird state with our alarm due to not always sending
success emails. We were set up to send success emails only on change.
Our utils-common master is currently building successfully, but we're in
alarm. Here's what happened.

1. Cron failed on Sunday -> email sent, parsed by our alarm since it is
a cron.
2. Rerun succeeded on Monday -> email sent, not parsed by our alarm
since it is not a cron.
3. Cron succeeded ever since -> email not sent since we only send emails
if build status changes.

Effectively, without doing this we will be stuck in alarm until the
build fails and then succeeds again with under a cron build.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
