### PR TITLE
Test workaround in travis-scripts for lcov 1.12 bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ env:
     - ROS_DISTRO=melodic ROS_VERSION=1
     - ROS_DISTRO=dashing ROS_VERSION=2
 install:
-  - git clone https://github.com/aws-robotics/travis-scripts.git .ros_ci
+  - git clone https://github.com/aws-robotics/travis-scripts.git -b lcov-bug .ros_ci
 script:
   - .ros_ci/ce_build.sh


### PR DESCRIPTION
*Description of changes:*

This [build failure](https://travis-ci.org/aws-robotics/utils-common/jobs/629816772) is the result of hitting a bug in `lcov 1.12`. A workaround has been implemented in `travis-scripts`, at https://github.com/aws-robotics/travis-scripts/pull/65. This draft pull request is for testing it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
