### PR TITLE
Add wordexp_ros wrapper for wordexp, allowing ROS-aware path expansion

### DIFF
--- a/aws_common/CMakeLists.txt
+++ b/aws_common/CMakeLists.txt
@@ -34,7 +34,8 @@ add_library(${PROJECT_NAME} SHARED
   src/sdk_utils/aws_profile_provider.cpp
   src/sdk_utils/client_configuration_provider.cpp
   src/sdk_utils/logging/aws_log_system.cpp
-  src/sdk_utils/auth/service_credentials_provider.cpp)
+  src/sdk_utils/auth/service_credentials_provider.cpp
+  src/fs_utils/wordexp_ros.cpp)
 add_dependencies(${PROJECT_NAME} AWS_SDK_IMPORT)
 
 foreach(_imported_lib ${${PROJECT_NAME}_IMPORTED_LIBRARIES})
@@ -68,6 +69,7 @@ add_common_gtest(test_aws_log_system test/sdk_utils/logging/aws_log_system_test.
 add_common_gtest(test_throttling_manager test/sdk_utils/throttling_manager_test.cpp)
 add_common_gtest(test_client_configuration_provider test/sdk_utils/client_configuration_provider_test.cpp)
 add_common_gtest(test_service_credentials_provider test/sdk_utils/auth/service_credentials_provider_test.cpp)
+add_common_gtest(test_wordexp_ros test/fs_utils/wordexp_ros_test.cpp)
 
 add_library(test_utils test/sdk_utils/parameter_reader_mock.cpp)
 target_include_directories(test_utils PUBLIC ${PROJECT_SOURCE_DIR}/test/include)
@@ -96,6 +98,7 @@ link_test_target(test_aws_log_system)
 link_test_target(test_throttling_manager)
 link_test_target(test_client_configuration_provider)
 link_test_target(test_service_credentials_provider)
+link_test_target(test_wordexp_ros)
 
 #############
 ## Install ##

--- a/aws_common/include/aws_common/fs_utils/wordexp_ros.h
+++ b/aws_common/include/aws_common/fs_utils/wordexp_ros.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#pragma once
+
+#include <wordexp.h>
+
+/**
+ * @brief Provide wordexp-like behavior, with one difference: in the case that $HOME is not defined -
+ *  use $ROS_HOME before falling back to looking up the PWD entry for the user.
+ */
+int wordexp_ros(const char *words, wordexp_t *pwordexp, int flags);

--- a/aws_common/src/fs_utils/wordexp_ros.cpp
+++ b/aws_common/src/fs_utils/wordexp_ros.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws_common/fs_utils/wordexp_ros.h>
+#include <wordexp.h>
+#include <stdlib.h>
+
+int wordexp_ros(const char *words, wordexp_t *pwordexp, int flags) {
+  bool should_unset_home = false;
+  if (NULL == getenv("HOME") && NULL != getenv("ROS_HOME")) {
+    // We don't want to change the behavior of anything else so we should unset HOME once we're done.
+    should_unset_home = true;
+    setenv("HOME", getenv("ROS_HOME"), true);
+  }
+
+  int wordexp_result = wordexp(words, pwordexp, flags);
+  if (should_unset_home) {
+    unsetenv("HOME");
+  }
+  return wordexp_result;
+}

--- a/aws_common/test/fs_utils/wordexp_ros_test.cpp
+++ b/aws_common/test/fs_utils/wordexp_ros_test.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <aws_common/fs_utils/wordexp_ros.h>
+#include <stdlib.h>
+
+class WordExpRosTestFixture : public ::testing::Test
+{
+protected:
+  void SetUp() override {
+    env_home = getenv("HOME");
+    env_ros_home = getenv("ROS_HOME");
+  }
+
+  void TearDown() override {
+    wordfree(&wordexp_standard);
+    wordfree(&wordexp_ros_expansion);
+    // Restore environment variables
+    if (NULL != env_home) {
+      setenv("HOME", env_home, 1);
+    }
+    if (NULL != env_ros_home) {
+      setenv("ROS_HOME", env_ros_home, 1);
+    }
+  }
+  wordexp_t wordexp_standard, wordexp_ros_expansion;
+  const char *env_home, *env_ros_home;
+};
+
+/*  Test Scenarios
+
+    HOME  | ROS_HOME | result:
+ 1. unset |  unset   | same as wordexp (home directory of pwd entry)
+ 2. set   |  unset   | same as wordexp ($HOME)
+ 3. set   |  set     | same as wordexp ($HOME)
+ 4. unset |  set     | ROS_HOME
+**/
+
+TEST_F(WordExpRosTestFixture, TestHomeUnsetRosHomeUnset)
+{
+  // Scenario 1
+  unsetenv("HOME");
+  unsetenv("ROS_HOME");
+  EXPECT_EQ(wordexp_ros("~", &wordexp_ros_expansion, 0), wordexp("~", &wordexp_standard, 0));
+  EXPECT_EQ(wordexp_ros_expansion.we_wordc, wordexp_standard.we_wordc);
+  EXPECT_STREQ(wordexp_ros_expansion.we_wordv[0], wordexp_standard.we_wordv[0]);
+}
+
+TEST_F(WordExpRosTestFixture, TestHomeSetRosHomeUnset)
+{
+  // Scenario 2
+  setenv("HOME", "/home/test2", true);
+  unsetenv("ROS_HOME");
+  EXPECT_EQ(wordexp_ros("~", &wordexp_ros_expansion, 0), wordexp("~", &wordexp_standard, 0));
+  EXPECT_EQ(wordexp_ros_expansion.we_wordc, wordexp_standard.we_wordc);
+  EXPECT_STREQ(wordexp_ros_expansion.we_wordv[0], wordexp_standard.we_wordv[0]);
+  EXPECT_STREQ(wordexp_ros_expansion.we_wordv[0], "/home/test2");
+}
+
+TEST_F(WordExpRosTestFixture, TestHomeSetRosHomeSet)
+{
+  // Scenario 3
+  setenv("HOME", "/home/test3", true);
+  setenv("ROS_HOME", "/home/roshome3", true);
+  EXPECT_EQ(wordexp_ros("~", &wordexp_ros_expansion, 0), wordexp("~", &wordexp_standard, 0));
+  EXPECT_EQ(wordexp_ros_expansion.we_wordc, wordexp_standard.we_wordc);
+  EXPECT_STREQ(wordexp_ros_expansion.we_wordv[0], wordexp_standard.we_wordv[0]);
+  EXPECT_STREQ(wordexp_ros_expansion.we_wordv[0], "/home/test3");
+}
+
+TEST_F(WordExpRosTestFixture, TestHomeUnsetRosHomeSet)
+{
+  // Scenario 4
+  unsetenv("HOME");
+  setenv("ROS_HOME", "/home/roshome4", true);
+  EXPECT_EQ(wordexp_ros("~", &wordexp_ros_expansion, 0), wordexp("~", &wordexp_standard, 0));
+  EXPECT_STRNE(wordexp_ros_expansion.we_wordv[0], wordexp_standard.we_wordv[0]);
+  EXPECT_STREQ(wordexp_ros_expansion.we_wordv[0], "/home/roshome4");
+  // Verify that HOME remains unchanged
+  EXPECT_EQ(getenv("HOME"), nullptr);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
`wordexp` (see http://man7.org/linux/man-pages/man3/wordexp.3.html) expands tilde by looking at $HOME. If $HOME is unset it will get the home directory from the pwd entry (`pw_dir` returned from http://man7.org/linux/man-pages/man3/getpwnam.3.html).
For ROS applications, before falling back to the pwd entry we'd like to use ROS_HOME if it exists. 

This would result in a functionality similar to the one implemented at https://github.com/aws-robotics/cloudwatch-common/pull/43, but better because we'd fallback to the pwd entry if no env variables are set. Plus, putting it here in aws_common so it'll be usable by other CEs, specifically for the rosbag uploader.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
