### PR TITLE
Remove manual install of importlib

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,4 +1,4 @@
-name: Test utils_common
+name: Build & Test utils_common
 on:
   pull_request:
   push:
@@ -32,7 +32,6 @@ jobs:
     # Needed for the CMakeLists.txt setup
     - run: export ROS_VERSION=2
     # Needed for missing dependencies
-    - run: python3 -m pip install -U --force-reinstall importlib-resources importlib-metadata
     - uses: ros-tooling/action-ros-ci@0.0.17
       with:
         source-ros-binary-installation: ${{ matrix.ros_distro }}

--- a/.github/workflows/build_and_test_release_latest.yml
+++ b/.github/workflows/build_and_test_release_latest.yml
@@ -1,5 +1,6 @@
 name: Build & Test utils_common release-latest
 on:
+  pull_request:
   schedule:
     # Run every hour. This helps detect flakiness,
     # and broken external dependencies.
@@ -27,7 +28,6 @@ jobs:
     - run: export ROS_DISTRO=${{ matrix.ros_distro }}
     # Needed for the CMakeLists.txt setup
     - run: export ROS_VERSION=2
-    - run: python3 -m pip install -U --force-reinstall importlib-resources importlib-metadata
     - uses: ros-tooling/action-ros-ci@0.0.17
       with:
         source-ros-binary-installation: ${{ matrix.ros_distro }}

--- a/.github/workflows/build_and_test_release_latest.yml
+++ b/.github/workflows/build_and_test_release_latest.yml
@@ -1,6 +1,5 @@
 name: Build & Test utils_common release-latest
 on:
-  pull_request:
   schedule:
     # Run every hour. This helps detect flakiness,
     # and broken external dependencies.


### PR DESCRIPTION
Removed unnecessary manual addition of importlib dependencies, which are not needed for dashing.

Signed-off-by: Devin Bonnie <dbbonnie@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
