### PR TITLE
Change cloudwatch metric being sent for ref

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -92,7 +92,7 @@ jobs:
         metric-dimensions: >-
           [
             { "Name": "github.event_name", "Value": "${{ github.event_name }}" },
-            { "Name": "github.ref", "Value": "build_and_test" },
+            { "Name": "github.ref", "Value": "${{ github.ref }}" },
             { "Name": "github.repository", "Value": "${{ github.repository }}" }
           ]
         # Checks if any of the jobs have failed.


### PR DESCRIPTION
Push to Cloudwatch with metric `{ "Name": "github.ref", "Value": "${{ github.ref }}" }` instead `{ "Name": "github.ref", "Value": "build_and_test" }`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
