### PR TITLE
Update README and comment out AWS SDK install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,11 @@ The source code is released under an [Apache 2.0].
 
 **Author**: AWS RoboMaker<br/>
 **Affiliation**: [Amazon Web Services (AWS)]<br/>
-**Maintainer**: AWS RoboMaker, ros-contributions@amazon.com
+
+RoboMaker cloud extensions rely on third-party software licensed under open-source licenses and are provided for demonstration purposes only. Incorporation or use of RoboMaker cloud extensions in connection with your production workloads or commercial product(s) or devices may affect your legal rights or obligations under the applicable open-source licenses. License information for this repository can be found [here](https://github.com/aws-robotics/utils-common/blob/master/LICENSE). AWS does not provide support for this cloud extension. You are solely responsible for how you configure, deploy, and maintain this cloud extension in your workloads or commercial product(s) or devices.
 
 ### Supported ROS Distributions
 - Melodic
-
-### Build status
-* GitHub Action Status
-     * master: [![Build & Test](https://github.com/aws-robotics/utils-common/workflows/Build%20&%20Test/badge.svg?branch=master&event=schedule)](https://github.com/aws-robotics/utils-common/actions?query=workflow%3A"Build+%26+Test"+event%3Aschedule)
-     * release-latest: [![Build & Test release-latest](https://github.com/aws-robotics/utils-common/workflows/Build%20&%20Test%20release-latest/badge.svg?branch=master&event=schedule)](https://github.com/aws-robotics/utils-common/actions?query=workflow%3A"Build+%26+Test+release-latest"+event%3Aschedule)
-* ROS build farm:
-    * ROS Kinetic @ u16.04 Xenial [![Build Status](http://build.ros.org/job/Kbin_uX64__aws_common__ubuntu_xenial_amd64__binary/badge/icon)](http://build.ros.org/job/Kbin_uX64__aws_common__ubuntu_xenial_amd64__binary)
-    * ROS Melodic @ u18.04 Bionic [![Build Status](http://build.ros.org/job/Mbin_uB64__aws_common__ubuntu_bionic_amd64__binary/badge/icon)](http://build.ros.org/job/Mbin_uB64__aws_common__ubuntu_bionic_amd64__binary)
-    * ROS Dashing @ u18.04 Bionic [![Build Status](http://build.ros2.org/job/Dbin_uB64__aws_common__ubuntu_bionic_amd64__binary/badge/icon)](http://build.ros2.org/job/Dbin_uB64__aws_common__ubuntu_bionic_amd64__binary)
 
 ## Installation
 

--- a/aws_common/awssdk/CMakeLists.txt
+++ b/aws_common/awssdk/CMakeLists.txt
@@ -1,40 +1,50 @@
-cmake_minimum_required(VERSION 3.0.2)
-project(AWSSDK)
-set(AWSSDK_VERSION 1.8.85)
-set(AWSSDK_MD5 889124168bfa13bf0c70c09c36c7ff36)
+# #############
+# ## Warning ##
+# #############
 
-if(NOT EXTERNAL_INSTALL_LOCATION)
-  set(EXTERNAL_INSTALL_LOCATION ${CMAKE_BINARY_DIR}/external)
-endif()
+# # AWS does not provide support for this cloud extension.
+# # You are solely responsible for how you configure, deploy, and maintain this
+# # cloud extension in your workloads or commercial product(s) or devices.
+# # You are solely responsible for testing and configuring the correct AWS SDK version.
 
-#############
-## Library ##
-#############
-file(MAKE_DIRECTORY ${EXTERNAL_INSTALL_LOCATION}/include)
-file(MAKE_DIRECTORY ${EXTERNAL_INSTALL_LOCATION}/lib)
+# cmake_minimum_required(VERSION 3.0.2)
+# project(AWSSDK)
+# # User replaces ADD_YOUR_VERSION_HERE and ADD_YOUR_MD5_HERE with their desired AWS SDK version and corresponding MD5
+# set(AWSSDK_VERSION ADD_YOUR_VERSION_HERE)
+# set(AWSSDK_MD5 ADD_YOUR_MD5_HERE)
 
-string(REPLACE ";" "$<SEMICOLON>" SERVICES_ARG "${SERVICE}")
+# if(NOT EXTERNAL_INSTALL_LOCATION)
+#   set(EXTERNAL_INSTALL_LOCATION ${CMAKE_BINARY_DIR}/external)
+# endif()
 
-include(ExternalProject)
-ExternalProject_Add(AWS_SDK_IMPORT
-  SOURCE_DIR ${EXTERNAL_INSTALL_LOCATION}/src
-  URL https://github.com/aws/aws-sdk-cpp/archive/${AWSSDK_VERSION}.tar.gz
-  URL_MD5 ${AWSSDK_MD5}
-  CMAKE_ARGS -DMINIMIZE_SIZE=TRUE -DENABLE_TESTING=FALSE -DBUILD_ONLY=${SERVICES_ARG} -DCPP_STANDARD=11 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${EXTERNAL_INSTALL_LOCATION}
-)
+# #############
+# ## Library ##
+# #############
+# file(MAKE_DIRECTORY ${EXTERNAL_INSTALL_LOCATION}/include)
+# file(MAKE_DIRECTORY ${EXTERNAL_INSTALL_LOCATION}/lib)
 
-#############
-## Install ##
-#############
+# string(REPLACE ";" "$<SEMICOLON>" SERVICES_ARG "${SERVICE}")
 
-install(DIRECTORY ${EXTERNAL_INSTALL_LOCATION}/lib/
-  DESTINATION lib/
-  FILES_MATCHING PATTERN "libaws*.so"
-)
+# include(ExternalProject)
+# ExternalProject_Add(AWS_SDK_IMPORT
+#   SOURCE_DIR ${EXTERNAL_INSTALL_LOCATION}/src
+#   URL https://github.com/aws/aws-sdk-cpp/archive/${AWSSDK_VERSION}.tar.gz
+#   URL_MD5 ${AWSSDK_MD5}
+#   CMAKE_ARGS -DMINIMIZE_SIZE=TRUE -DENABLE_TESTING=FALSE -DBUILD_ONLY=${SERVICES_ARG} -DCPP_STANDARD=11 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${EXTERNAL_INSTALL_LOCATION}
+# )
 
-install(
-  DIRECTORY ${EXTERNAL_INSTALL_LOCATION}/include/aws
-  DESTINATION include/
-)
+# #############
+# ## Install ##
+# #############
 
-export(PACKAGE ${PROJECT_NAME})
+# install(DIRECTORY ${EXTERNAL_INSTALL_LOCATION}/lib/
+#   DESTINATION lib/
+#   FILES_MATCHING PATTERN "libaws*.so"
+# )
+
+# install(
+#   DIRECTORY ${EXTERNAL_INSTALL_LOCATION}/include/aws
+#   DESTINATION include/
+# )
+
+# export(PACKAGE ${PROJECT_NAME})


### PR DESCRIPTION
*Description of changes:*
Update README to reflect current state of AWS and Cloud Extensions.
Remove obsolete build status section.
Comment out the out-of-date AWS SDK CMakeList and specify the user's responsibility for defining their desired AWS SDK version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
